### PR TITLE
Improve hero bubble responsiveness on small screens

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -400,6 +400,25 @@ header {
   }
 }
 
+@media (max-width: 400px) {
+  .resaltado-hero-title,
+  .resaltado-hero-sub,
+  .resaltado-hero {
+    display: block;
+    width: 100%;
+  }
+  .resaltado-hero-title {
+    font-size: 1.6rem;
+  }
+  .resaltado-hero-sub {
+    font-size: 0.95rem;
+  }
+  .resaltado-hero {
+    font-size: 0.9rem;
+    padding: 0.6em 0.9em;
+  }
+}
+
 /* SERVICIOS */
 .servicios {
   background: var(--blanco);


### PR DESCRIPTION
## Summary
- ensure hero highlight bubbles display correctly on screens under 400px by converting them to block elements and reducing font size/padding

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e13bb005483228d3533a1cd202c02