### PR TITLE
Hacer transparente el cuadro informativo del hero

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -321,7 +321,7 @@ header {
 }
 .resaltado-hero {
   display: inline-block;
-  background: rgba(255,255,255,0.5);
+  background: transparent;
   color: var(--color-texto, #b91732);
   padding: 0.7em 1.5em;
   border-radius: 1em;
@@ -337,7 +337,7 @@ header {
 }
 .resaltado-hero-title {
   display: inline-block;
-  background: rgba(255,255,255,0.5);
+  background: transparent;
   color: var(--color-principal, #b91732);
   padding: 0.17em 0.9em 0.18em 0.9em;
   border-radius: 1.2em;
@@ -354,7 +354,7 @@ header {
 
 .resaltado-hero-sub {
   display: inline-block;
-  background: rgba(255,255,255,0.5);
+  background: transparent;
   color: var(--verde-oscuro, #189945);
   padding: 0.13em 1em 0.13em 1em;
   border-radius: 1.2em;
@@ -371,18 +371,18 @@ header {
 
 @media (prefers-color-scheme: dark) {
   .resaltado-hero-title {
-    background: rgba(253, 252, 252, 0.5);
+    background: transparent;
     color: #a81c1c;
   }
   .resaltado-hero-sub {
-    background: rgba(253, 252, 252, 0.5);
+    background: transparent;
     color: #090606;
   }
 }
 
 @media (prefers-color-scheme: dark) {
   .resaltado-hero {
-    background: rgba(79, 47, 47, 0.5); /* Un fondo claro más sutil en oscuro */
+    background: transparent;
     color: #170505;
   }
 }


### PR DESCRIPTION
## Summary
- Hacer transparente los recuadros del hero para mostrar sólo el texto

## Testing
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e4882e25c8322b238968becb0a9fa