### PR TITLE
Add text bubble and shadow to hero section

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -321,13 +321,14 @@ header {
 }
 .resaltado-hero {
   display: inline-block;
-  background: transparent;
+  background: rgba(255,255,255,0.85);
   color: var(--color-texto, #b91732);
   padding: 0.7em 1.5em;
   border-radius: 1em;
   border-top-right-radius: 0;
   border-bottom-left-radius: 0;
   box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+  text-shadow: 1px 1px 3px rgba(0,0,0,0.3);
   font-weight: 500;
   margin-bottom: 1.2em;
   transition: background .3s, color .3s;
@@ -337,13 +338,14 @@ header {
 }
 .resaltado-hero-title {
   display: inline-block;
-  background: transparent;
+  background: rgba(255,255,255,0.85);
   color: var(--color-principal, #b91732);
   padding: 0.17em 0.9em 0.18em 0.9em;
   border-radius: 1.2em;
   border-top-right-radius: 0;
   border-bottom-left-radius: 0;
   box-shadow: 0 4px 24px rgba(21, 9, 9, 0.07);
+  text-shadow: 2px 2px 4px rgba(0,0,0,0.25);
   font-weight: 700;
   margin-bottom: 0.3em;
   transition: background .3s, color .3s;
@@ -354,13 +356,14 @@ header {
 
 .resaltado-hero-sub {
   display: inline-block;
-  background: transparent;
+  background: rgba(255,255,255,0.85);
   color: var(--verde-oscuro, #189945);
   padding: 0.13em 1em 0.13em 1em;
   border-radius: 1.2em;
   border-top-right-radius: 0;
   border-bottom-left-radius: 0;
   box-shadow: 0 4px 20px rgba(0,0,0,0.05);
+  text-shadow: 1px 1px 3px rgba(0,0,0,0.3);
   font-weight: 600;
   margin-bottom: 1.1em;
   transition: background .3s, color .3s;
@@ -370,20 +373,12 @@ header {
 }
 
 @media (prefers-color-scheme: dark) {
-  .resaltado-hero-title {
-    background: transparent;
-    color: #a81c1c;
-  }
-  .resaltado-hero-sub {
-    background: transparent;
-    color: #090606;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
+  .resaltado-hero-title,
+  .resaltado-hero-sub,
   .resaltado-hero {
-    background: transparent;
-    color: #170505;
+    background: rgba(0,0,0,0.6);
+    color: #fff;
+    text-shadow: 1px 1px 3px rgba(0,0,0,0.8);
   }
 }
 


### PR DESCRIPTION
## Summary
- Give hero headlines semi-transparent backgrounds and text shadows for a balloon effect
- Support the new styling in dark mode

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688e5413ecfc8322b5511c2838f8a69d