### PR TITLE
Estilo de scroll y títulos

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -44,6 +44,16 @@ body {
   min-height: 100vh;
 }
 
+/* Sombreado sutil color cereza para todos los títulos */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-shadow: 0 1px 3px rgba(185, 23, 50, 0.3);
+}
+
 /* Enlaces y botones */
 a {
   color: var(--color-principal);
@@ -913,6 +923,21 @@ body {
   color: var(--color-texto);
   font-family: 'Montserrat', Arial, Helvetica, sans-serif;
   min-height: 100vh;
+  scrollbar-color: var(--color-principal) rgba(0, 0, 0, 0.5);
+}
+
+/* Barra de desplazamiento con fondo 50% transparente */
+body::-webkit-scrollbar {
+  width: 12px;
+}
+
+body::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+body::-webkit-scrollbar-thumb {
+  background-color: var(--color-principal);
+  border-radius: 6px;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- Agrega sombreado sutil color cereza a todos los títulos
- Personaliza la barra de desplazamiento con fondo 50% transparente y thumb en color principal

## Testing
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e58bcf4a48322b4a4ff833b3d7ae7